### PR TITLE
Fixed the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ $ npm install gitlog-parser --save
 var parselog = require('gitlog-parser').parse;
 var exec = require('child_process').exec;
 
-parselog(exec('git log')).on('commit', function(commit) {
+parselog(exec('git log').stdout).on('commit', function(commit) {
   // hash
   // author
   // message
   // ...
 });
 
-parselog(exec('git log index.js')).on('commit', function(commit) {
+parselog(exec('git log index.js').stdout).on('commit', function(commit) {
   // just show the history of index.js
 });
 ```


### PR DESCRIPTION
Provide the stdout in parselog function, otherwise an error appears because `Exec` doesn't return a stream. `stdout` is a stream.

Thanks for this nice module, btw! :smile: 
